### PR TITLE
fix of gyration tensor calculation

### DIFF
--- a/amep/pbc.py
+++ b/amep/pbc.py
@@ -596,7 +596,8 @@ def pbc_diff_rect(v1, v2, box_boundary):
         v = v1 - v2
         
     # fold distance vectors back into the box
-    v = fold(v, box_boundary)
+    # must fold with respect to center of box
+    v = fold(v, box_boundary-np.mean(box_boundary, axis=1)[:,None])
     return v
 
 


### PR DESCRIPTION
this merge fixes #78 and fixes #79 by correcting the calculation of the periodic distances with `pbc_diff_rect` and `pbc_diff`.