### PR TITLE
Improve documentation

### DIFF
--- a/amep/base.py
+++ b/amep/base.py
@@ -1141,6 +1141,7 @@ class BaseField:
     def box(self)->np.ndarray:
         '''
         Box boundaries of the simulation.
+        
         Returns
         -------
         boxe : np.ndarray

--- a/amep/continuum.py
+++ b/amep/continuum.py
@@ -54,7 +54,7 @@ def coords_to_density(
     r"""
     Convert the particle coordinates into a 2D density field.
 
-    With size gridsize^2 by calculating a 2D histogram of the
+    With size `gridsize`:math:`{}^2` by calculating a 2D histogram of the
     x and y coordinates of the particles.
 
     Notes
@@ -153,7 +153,7 @@ def sf2d(
     The static structure factor is defined by
 
     .. math::
-        S(\vec{q}) = <\rho(\vec{q})\rho(\vec{-q})>= <|\rho(\vec{q})|^2>,
+        S(\vec{q}) = \langle\rho(\vec{q})\rho(\vec{-q})\rangle= \langle|\rho(\vec{q})|^2\rangle,
 
     where :math:`\rho(\vec{q})` is the Fourier transform of the particle number
     density (see Ref. [1]_ [2]_ [3]_ for further information).
@@ -172,7 +172,7 @@ def sf2d(
        https://doi.org/10.1038/ncomms5351
 
 
-    S(0,0) is set to 0
+    :math:`S(0,0)` is set to :math:`0`
 
     Parameters
     ----------
@@ -421,9 +421,9 @@ def gkde(
     -----
     The Kernel Density Estimation (KDE) method uses a continuous kernel
     function, which needs to be normalized to one. In KDE, a kernel function
-    k of width h is placed at each position of the particles. Then, all kernel
+    :math:`k` of width :math:`h` is placed at each position of the particles. Then, all kernel
     functions are summed to get the final density estimate. There two
-    "parameters": the form of the kernel function k and its width.
+    "parameters": the form of the kernel function :math:`k` and its width.
 
     This method is nicely described on page 13 ff. in Ref. [1]_.
 

--- a/amep/evaluate.py
+++ b/amep/evaluate.py
@@ -598,7 +598,7 @@ class PCF2d(BaseEvaluation):
             ptype: int | None = None, other: int | None = None,
             **kwargs) -> None:
         r'''
-        Calculate the two-dimensional pair correlation function g(x,y).
+        Calculate the two-dimensional pair correlation function :math:`g(x,y)`.
         
         Implemented for a 2D system.
         Takes the time average over several time steps.
@@ -813,7 +813,7 @@ class PCFangle(BaseEvaluation):
             ptype: int | None = None, other: int | None = None,
             **kwargs) -> None:
         r'''
-        Calculate the two-dimensional pair correlation function g(r,theta).
+        Calculate the two-dimensional pair correlation function :math:`g(r,\theta)`.
 
         Implemented for a 2D system.
         Takes the time average over several time steps.
@@ -1405,7 +1405,7 @@ class SFiso(BaseEvaluation):
             S_{3D}(q) = \frac{1}{N}\left\langle\sum_{m,l=1}^N\frac{\sin(qr_{ml})}{qr_{ml}}\right\rangle
 
         .. math::
-            S_{2D}(q) = \frac{1}{N}\left\langle\sum_{m,l=1}^N J_0(qr_{ml}\right\rangle
+            S_{2D}(q) = \frac{1}{N}\left\langle\sum_{m,l=1}^N J_0(qr_{ml})\right\rangle
 
         with :math:`r_{ml}=|\vec{r}_m-\vec{r}_l|` and the Bessel function
         of the first kind :math:`J_0(x)`.
@@ -1706,14 +1706,14 @@ class PosOrderCor(BaseEvaluation):
         r'''
         Calculate the positional order correlation function.
 
-        Based on the pair correlation function g(r,theta).
+        Based on the pair correlation function :math:`g(r,\theta)`.
 
         Notes
         -----
         The positional order correlation function is defined as
 
         .. math::
-            C_{\vec{k}_0}(r) = <\exp(i\vec{k}_0\cdot (\vec{r}_j-\vec{r}_l))>
+            C_{\vec{k}_0}(r) = \langle\exp(i\vec{k}_0\cdot (\vec{r}_j-\vec{r}_l))\rangle
 
         with :math:`r=|\vec{r}_j-\vec{r}_l|` (see Ref. [1]_ for further information).
         As shown in Ref. [2]_, this can be rewritten as
@@ -1942,15 +1942,15 @@ class HexOrderCor(BaseEvaluation):
         .. math::
             \Psi_6(\vec{r}_j)=\frac{1}{N_j}\sum_{k=1}^{N_j}\exp(i6\theta_{jk})
 
-        where the sum goes over the six next neighbors of particle j.
+        where the sum goes over the six next neighbors of particle :math:`j`.
         The angle :math:`\theta_{jk}` denotes the angle between the vector
-        that connects particle j with its k-th nearest neighbor and
+        that connects particle :math:`j` with its :math:`k`-th nearest neighbor and
         the x-axis. The hexagonal order correlation function is then
         defined by
 
         .. math::
-            g_6(r=|\vec{r}_j-\vec{r}_i|)=<\Psi_6(\vec{r}_j)\Psi_6(\vec{r}_i)> /
-            <\Psi_6^2(\vec{r}_j)>.
+            g_6(r=|\vec{r}_j-\vec{r}_i|)=\langle\Psi_6(\vec{r}_j)\Psi_6(\vec{r}_i)\rangle /
+            \langle\Psi_6^2(\vec{r}_j)\rangle.
 
         See Refs. [1]_ [2]_ [3]_ for further information.
 
@@ -2768,9 +2768,9 @@ class VelDist(BaseEvaluation):
         bins are used. Therefore `v2min`:math:`\ge 0`
         needs to be ensured. For the maximum value,
         `vmax` is used as :math:`3v_{max}^2`.
-        Analogously for the maximum of :math:'v',
+        Analogously for the maximum of :math:`v`,
         where :math:`\sqrt{3v_{max}}` is used. For the minimum
-        of :math:'v', the square root of `v2min` is used.
+        of :math:`v`, the square root of `v2min` is used.
 
         Parameters
         ----------
@@ -3310,8 +3310,8 @@ class ClusterSizeDist(BaseEvaluation):
         .. math::
             p(m) = m \frac{n_m}{N},
 
-        where m is the cluster size, n_m the number of clusters with size m,
-        and N the total number of particles. See Ref. [1]_ for further
+        where :math:`m` is the cluster size, :math:`n_m` the number of clusters with size :math:`m`,
+        and :math:`N` the total number of particles. See Ref. [1]_ for further
         information.
 
         References

--- a/amep/functions.py
+++ b/amep/functions.py
@@ -72,7 +72,7 @@ def gaussian(
     Returns
     -------
     np.ndarray
-        g(x)
+        :math:`g(x)`
 
     Examples
     --------

--- a/amep/order.py
+++ b/amep/order.py
@@ -1186,9 +1186,9 @@ def k_nearest_neighbors(
         k: int = 1, pbc : bool = True,
         rmax : float = np.inf, enforce_nd: int | None = None) -> np.ndarray:
     r'''
-    Calculates the k nearest neighbors and returns the number of nearest
-    neighbors (can be different from k if a distance cutoff is given),
-    the k nearest-neighbor distances, and the k nearest-neighbor indices.
+    Calculates the :math:`k` nearest neighbors and returns the number of nearest
+    neighbors (can be different from :math:`k` if a distance cutoff is given),
+    the :math:`k` nearest-neighbor distances, and the :math:`k` nearest-neighbor indices.
 
     Parameters
     ----------
@@ -1363,21 +1363,21 @@ def psi_k(
         other_coords: np.ndarray | None = None,
         rmax: float = 1.122, k: int = 6, pbc: bool = True) -> np.ndarray:
     r'''
-    Calculates the k-atic bond order parameter for an entire 2D system.
+    Calculates the :math:`k`-atic bond order parameter for an entire 2D system.
 
-    In a first step, the indexes of the first k next neighbors of each
+    In a first step, the indexes of the first :math:`k` next neighbors of each
     atom is calculated with the KDTree algorithm and with periodic
     boundary conditions appplied with pbc_points.
 
 
     Notes
     -----
-    The k-atic order parameter is defined by
+    The :math:`k`-atic order parameter is defined by
 
     .. math::
         \Psi_k(\vec{r}_j) = \frac{1}{k} \sum_{n=1}^k\exp(ik\theta_{jn}),
 
-    where the sum goes over the k nearest neighbors of the particle at
+    where the sum goes over the :math:`k` nearest neighbors of the particle at
     position :math:`\vec{r}_j`. The value of :math:`\theta_{jn}` is equal to the angle
     between the connection line from :math:`\vec{r}_j` to :math:`\vec{r}_n` and the
     x axis. See also Refs. [1]_ [2]_ [3]_ for further information.
@@ -1422,7 +1422,7 @@ def psi_k(
     Returns
     -------
     np.ndarray
-        k-atic order parameter of each particle (1D array of
+        :math:`k`-atic order parameter of each particle (1D array of
         complex numbers).
 
     Examples

--- a/amep/spatialcor.py
+++ b/amep/spatialcor.py
@@ -146,7 +146,7 @@ def spatialcor(
         pbc: bool = True) -> tuple[np.ndarray, np.ndarray]:
     r'''
     Calculates the spatial correlation function of the values for atoms 
-    at positions given by coords. Distances are calculated by the cKDTree
+    at positions given by `coords`. Distances are calculated by the cKDTree
     algorithm.
 
     Notes
@@ -154,10 +154,10 @@ def spatialcor(
     Works only for 2D systems in this version.
     
     The spatial correlation function is defined by the following equation
-    in which f can be a complex-valued scalar or vector:
+    in which :math:`f` can be a complex-valued scalar or vector:
     
     .. math::
-                C(r) = <f(r)*f(0)> / <f(0)^2>.
+                C(r) = \langle f(r)*f(0)\rangle / \langle f(0)^2\rangle.
     
     Parameters
     ----------
@@ -435,14 +435,14 @@ def rdf(
     Notes
     -----
     The radial pair-distribution function between two particle species
-    i and j is defined by (see Refs. [1]_ [2]_)
+    :math:`i` and :math:`j` is defined by (see Refs. [1]_ [2]_)
 
     .. math::
                 g_{ij}(r) = \frac{1}{\rho_j N_i}\sum\limits_{k\in S_i}
                             \sum\limits_{\substack{l\in S_j \\ l\neq k}}
                             \left\langle\frac{\delta\left(r-\left|\vec{r}_k(t)-\vec{r}_l(t)\right|\right)}{4\pi r^2}\right\rangle_t
 
-    For i=j we have
+    For :math:`i=j` we have
 
     .. math::
                 g(r) = \frac{1}{\rho N}\sum\limits_{k}\sum\limits_{l\neq k}
@@ -492,7 +492,7 @@ def rdf(
     Returns
     -------
     gr : np.ndarray
-        g(r) (1D array of floats)
+        :math:`g(r)` (1D array of floats)
     r : np.ndarray
         distances (1D array of floats)
         
@@ -746,7 +746,7 @@ def pcf2d(
     Notes
     -----
     The 2D pair correlation function between the particles themselfes, i.e.,
-    for i=j, is defined by
+    for :math:`i=j`, is defined by
 
     .. math::
                g(x,y) = \frac{1}{\rho N}\sum\limits_{i=1}^{N}
@@ -805,7 +805,7 @@ def pcf2d(
     Returns
     -------
     np.ndarray
-        g(x,y) (2D array of floats)
+        :math:`g(x,y)` (2D array of floats)
     np.ndarray
         x coordinate values (1D array of floats)
     np.ndarray
@@ -1642,7 +1642,7 @@ def sf2d(
     where :math:`\rho(\vec{q})` is the Fourier transform of the particle number
     density (see Ref. [1]_ for further information).
 
-    S(0,0) is set to 0
+    :math:`S(0,0)` is set to :math:`0`
 
     References
     ----------

--- a/amep/statistics.py
+++ b/amep/statistics.py
@@ -45,7 +45,7 @@ def binder_cumulant(data: np.ndarray) -> float:
 
     Notes
     -----
-    The Binder cumulant of a quantity x is defined by
+    The Binder cumulant of a quantity :math:`x` is defined by
 
     .. math::
         

--- a/amep/utils.py
+++ b/amep/utils.py
@@ -388,7 +388,7 @@ def profile(
 # =============================================================================
 def unit_vector_2D(theta: float | np.ndarray) -> np.ndarray:
     r'''
-    Generates 2D unit vectors in the x-y plane with angle theta to the x axis.
+    Generates 2D unit vectors in the x-y plane with angle `theta` to the x axis.
 
     Parameters
     ----------
@@ -1140,7 +1140,7 @@ def sq_from_gr(
 
     Notes
     -----
-    The relation between g(r) and S(q) is given by (here in 3D; see Ref. [1]_
+    The relation between :math:`g(r)` and :math:`S(q)` is given by (here in 3D; see Ref. [1]_
     for further information)
 
     .. math::
@@ -1167,8 +1167,8 @@ def sq_from_gr(
     twod : bool, default=True
         If True, the slightly different formula for the two-dimensional case
         is used (which includes a Bessel function and can be derived by
-        using zylindrical coordinates and calculating the angular integral by
-        setting w.l.o.g. q parallel to e_x.)
+        using cylindrical coordinates and calculating the angular integral by
+        setting w.l.o.g. :math:`q` parallel to :math:`e_x`.)
 
     Returns
     -------

--- a/doc/source/user_guide/data_formats/lammps_data.rst
+++ b/doc/source/user_guide/data_formats/lammps_data.rst
@@ -22,8 +22,8 @@ Or for reduced informations in the dump files, only positions and velocities:
     dump myDump all custom ${savesnap} dump*.txt id x y vx vy
     dump_modify myDump sort id
 
-We reccommend to always sort by id. Unsorted data causes many analyses to return wrong results.
-Currently, we also reccommend to save the id, type, mass and radius, especially if the particles
+We recommend to always sort by id. Unsorted data causes many analyses to return wrong results.
+Currently, we also recommend to save the id, type, mass and radius, especially if the particles
 are not identical and have different properties.
 Missing information in the dump files can also be added in **AMEP** with the following lines:
 


### PR DESCRIPTION
fixes #109 

Additional changes:
- Corrected this formatting issue in `amep.base.BaseField`:
![image](https://github.com/user-attachments/assets/cb422477-f6ba-4f22-aa73-f5689a0abb59)
- Spelling mistakes in `doc/source/user_guide/data_formats/lammps_data.rst` and `amep/utils.py`

Modified the following files:
- `amep/base.py`                                      
- `amep/continuum.py`                                 
- `amep/evaluate.py`                                  
- `amep/functions.py`                                 
- `amep/order.py`                                     
- `amep/spatialcor.py`                                
- `amep/statistics.py`                                
- `amep/utils.py`                                     
- `doc/source/user_guide/data_formats/lammps_data.rst`